### PR TITLE
V2 — Higher-Order Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
+**V2 is a higher-ordered component, improving compatibility with React 0.14+**
+
 ### Install
 ```
-npm install react-d3-wrap
+npm install react-d3-wrap --save
 ```
 
 ### Define a D3 component
-Extend the wrapper then override `update` to implement your D3 graphics. Optionally, if you have setup or cleanup to do, override `initialize` or `destroy`.
-```js
-import D3Wrap from 'react-d3-wrap'
+`d3Wrap()` returns a React component that sets up a svg element and hooks `initialize()`, `update()` and `destroy()` functions into component lifecycle.
+```
+import d3Wrap from 'react-d3-wrap'
 
-export default class MyChart extends D3Wrap {
+const MyChart = d3Wrap({
   initialize (svg, data, options) {
     // Optional initialize method called once when component mounts
-  }
+  },
 
   update (svg, data, options) {
     // setup container, root svg element passed in along with data and options
@@ -19,25 +21,21 @@ export default class MyChart extends D3Wrap {
       .append('g')
       .attr('transform', `translate(${options.margin.left}, ${options.margin.top})`)
 
-    // continue you d3 implementation as usual...
-  }
+    // continue your d3 implementation as usual...
+  },
 
   destroy () {
-    // clean up...
+    // Optional clean up when a component is being unmounted...
   }
-}
+})
+
+export default MyChart
 ```
 
-### Usage
-```js
-import MyChart from './MyChart'
-
-// Use options to pass in configuration and callbacks
-React.render(<MyChart 
-  data={ [0, 1, 2] }
-  width='400'
-  height='300'
-  options={{ onClick: this.handleClick }} />, document.getElementById('chart'))
+### How to use your custom D3 component
+`data`, `width` and `height` are required props. Use options to pass configuration and callbacks into initialize and update methods.
+```
+<MyChart data={ [0, 1, 2] } width='400' height='300' options={ {color: '#ff0000'} } />
 ```
 
 #### Default options

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,101 +1,104 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', {
+Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+exports.default = d3Wrap;
 
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _d3 = require('d3');
+var _reactDom = require('react-dom');
 
-var _d32 = _interopRequireDefault(_d3);
+var _d = require('d3');
 
-var _lodashAssign = require('lodash.assign');
+var _d2 = _interopRequireDefault(_d);
 
-var _lodashAssign2 = _interopRequireDefault(_lodashAssign);
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var ReactD3 = (function (_React$Component) {
-  _inherits(ReactD3, _React$Component);
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-  function ReactD3() {
-    _classCallCheck(this, ReactD3);
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-    _get(Object.getPrototypeOf(ReactD3.prototype), 'constructor', this).apply(this, arguments);
-  }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-  _createClass(ReactD3, [{
-    key: 'initialize',
-    value: function initialize(svg, data, options) {}
-  }, {
-    key: 'update',
-    value: function update(svg, data, options) {}
-  }, {
-    key: 'destroy',
-    value: function destroy() {}
-  }, {
-    key: 'componentDidMount',
-    value: function componentDidMount() {
-      this.initialize(_react2['default'].findDOMNode(this), this.props.data, this._getOptions(this.props.options));
-      this.update(_react2['default'].findDOMNode(this), this.props.data, this._getOptions(this.props.options));
+function d3Wrap(lifecycle) {
+  var d3Lifecycle = _extends({
+    initialize: function initialize(svg, data, options) {},
+    update: function update(svg, data, options) {},
+    destroy: function destroy() {}
+  }, lifecycle);
+
+  var D3Wrap = function (_Component) {
+    _inherits(D3Wrap, _Component);
+
+    function D3Wrap() {
+      _classCallCheck(this, D3Wrap);
+
+      return _possibleConstructorReturn(this, Object.getPrototypeOf(D3Wrap).apply(this, arguments));
     }
-  }, {
-    key: 'componentDidUpdate',
-    value: function componentDidUpdate() {
-      this.update(_react2['default'].findDOMNode(this), this.props.data, this._getOptions(this.props.options));
-    }
-  }, {
-    key: 'componentWillUnmount',
-    value: function componentWillUnmount() {
-      this.destroy();
-    }
-  }, {
-    key: 'render',
-    value: function render() {
-      var classes = 'd3-wrap';
-      if (this.props.className) {
-        classes = classes.concat(' ', this.props.className);
+
+    _createClass(D3Wrap, [{
+      key: 'componentDidMount',
+      value: function componentDidMount() {
+        d3Lifecycle.initialize.call(this, (0, _reactDom.findDOMNode)(this), this.props.data, this._getOptions(this.props.options));
+        d3Lifecycle.update.call(this, (0, _reactDom.findDOMNode)(this), this.props.data, this._getOptions(this.props.options));
       }
+    }, {
+      key: 'componentDidUpdate',
+      value: function componentDidUpdate() {
+        d3Lifecycle.update.call(this, (0, _reactDom.findDOMNode)(this), this.props.data, this._getOptions(this.props.options));
+      }
+    }, {
+      key: 'componentWillUnmount',
+      value: function componentWillUnmount() {
+        d3Lifecycle.destroy.call(this);
+      }
+    }, {
+      key: '_getOptions',
+      value: function _getOptions(propOps) {
+        var options = typeof propOps === 'undefined' ? {} : propOps;
+        return _extends({
+          margin: {
+            top: 0,
+            bottom: 0,
+            left: 0,
+            right: 0
+          },
+          xaxis: { orientation: 'bottom' },
+          yaxis: { orientation: 'left' }
+        }, options);
+      }
+    }, {
+      key: 'render',
+      value: function render() {
+        var _props = this.props;
+        var className = _props.className;
+        var width = _props.width;
+        var height = _props.height;
 
-      return _react2['default'].createElement('svg', { className: classes, width: this.props.width, height: this.props.height });
-    }
-  }, {
-    key: '_getOptions',
-    value: function _getOptions(propOps) {
-      var options = typeof propOps === 'undefined' ? {} : propOps;
-      return (0, _lodashAssign2['default'])({
-        margin: {
-          top: 0,
-          bottom: 0,
-          left: 0,
-          right: 0
-        },
-        xaxis: { orientation: 'bottom' },
-        yaxis: { orientation: 'left' }
-      }, options);
-    }
-  }]);
+        var classes = 'd3-wrap';
+        if (className) classes = classes.concat(' ', this.props.className);
 
-  return ReactD3;
-})(_react2['default'].Component);
+        return _react2.default.createElement('svg', { className: classes, width: width, height: height });
+      }
+    }]);
 
-exports['default'] = ReactD3;
+    return D3Wrap;
+  }(_react.Component);
 
-ReactD3.propTypes = {
-  data: _react2['default'].PropTypes.array.isRequired,
-  width: _react2['default'].PropTypes.number.isRequired,
-  height: _react2['default'].PropTypes.number.isRequired,
-  options: _react2['default'].PropTypes.object
-};
-module.exports = exports['default'];
+  D3Wrap.propTypes = {
+    data: _react2.default.PropTypes.array.isRequired,
+    width: _react2.default.PropTypes.number.isRequired,
+    height: _react2.default.PropTypes.number.isRequired,
+    options: _react2.default.PropTypes.object
+  };
+
+  return D3Wrap;
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "react-d3-wrap",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "React component wrapper for d3 elements.",
   "main": "lib/index.js",
   "scripts": {
-    "build": "babel -d lib/ src/",
+    "build": "babel src/ --out-dir lib/ -d --presets es2015,stage-2,react",
     "prepublish": "npm run build"
   },
   "keywords": [
@@ -16,13 +16,16 @@
   ],
   "author": "Shawn Kelly",
   "license": "MIT",
-  "dependencies": {
-    "d3": "^3.5.6",
-    "lodash.assign": "^3.2.0",
-    "react": "^0.13.3"
+  "peerDependencies": {
+    "d3": "^3.5",
+    "react": "^0.14",
+    "react-dom": "^0.14"
   },
   "devDependencies": {
-    "babel": "^5.8.9"
+    "babel-cli": "^6.6.5",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-2": "^6.5.0"
   },
   "homepage": "https://github.com/skellyb/react-d3-wrap",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,55 +1,59 @@
-import React from 'react'
+import React, { Component } from 'react'
+import { findDOMNode } from 'react-dom'
 import d3 from 'd3'
-import assign from 'lodash.assign'
 
-export default class ReactD3 extends React.Component {
-
-  initialize (svg, data, options) {}
-
-  update (svg, data, options) {}
-
-  destroy () {}
-
-  componentDidMount () {
-    this.initialize(React.findDOMNode(this), this.props.data, this._getOptions(this.props.options))
-    this.update(React.findDOMNode(this), this.props.data, this._getOptions(this.props.options))
+export default function d3Wrap (lifecycle) {
+  const d3Lifecycle = {
+    initialize (svg, data, options) {},
+    update (svg, data, options) {},
+    destroy () {},
+    ...lifecycle
   }
 
-  componentDidUpdate () {
-    this.update(React.findDOMNode(this), this.props.data, this._getOptions(this.props.options))
-  }
-
-  componentWillUnmount () {
-    this.destroy()
-  }
-
-  render () {
-    var classes = 'd3-wrap'
-    if (this.props.className) {
-      classes = classes.concat(' ', this.props.className)
+  class D3Wrap extends Component {
+    componentDidMount () {
+      d3Lifecycle.initialize.call(this, findDOMNode(this), this.props.data, this._getOptions(this.props.options))
+      d3Lifecycle.update.call(this, findDOMNode(this), this.props.data, this._getOptions(this.props.options))
     }
 
-    return <svg className={ classes } width={ this.props.width } height={ this.props.height } />
+    componentDidUpdate () {
+      d3Lifecycle.update.call(this, findDOMNode(this), this.props.data, this._getOptions(this.props.options))
+    }
+
+    componentWillUnmount () {
+      d3Lifecycle.destroy.call(this, )
+    }
+
+    _getOptions (propOps) {
+      const options = (typeof propOps === 'undefined') ? {} : propOps
+      return {
+        margin: {
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0
+        },
+        xaxis: { orientation: 'bottom' },
+        yaxis: { orientation: 'left' },
+        ...options
+      }
+    }
+
+    render () {
+      const { className, width, height } = this.props
+      let classes = 'd3-wrap'
+      if (className) classes = classes.concat(' ', this.props.className)
+
+      return <svg className={ classes } width={ width } height={ height } />
+    }
   }
 
-  _getOptions (propOps) {
-    const options = (typeof propOps === 'undefined') ? {} : propOps
-    return assign({
-      margin: {
-        top: 0,
-        bottom: 0,
-        left: 0,
-        right: 0
-      },
-      xaxis: { orientation: 'bottom' },
-      yaxis: { orientation: 'left' }
-    }, options)
+  D3Wrap.propTypes = {
+    data: React.PropTypes.array.isRequired,
+    width: React.PropTypes.number.isRequired,
+    height: React.PropTypes.number.isRequired,
+    options: React.PropTypes.object
   }
-}
 
-ReactD3.propTypes = {
-  data: React.PropTypes.array.isRequired,
-  width: React.PropTypes.number.isRequired,
-  height: React.PropTypes.number.isRequired,
-  options: React.PropTypes.object
+  return D3Wrap
 }


### PR DESCRIPTION
This moves away from subclassing React.Component. The same functionality is provided via a higher-order function that returns component wired up to some lifecycle methods. This allows you to use [common D3 pattens](https://bl.ocks.org/mbostock/3808218) inside a React app.
